### PR TITLE
Use builds for multi-arch builds and GitHub actions to release

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+
+[*.{yaml,yml}]
+indent_size = 2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,26 @@
+name: Docker Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:    
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout source  
+      uses: actions/checkout@v3
+    
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Setup multi-arch build tools
+      uses: docker/setup-buildx-action@v2
+      with:
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
+
+    - name: Multi-arch Docker Build
+      run: |
+        make docker-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.7-alpine AS build_deps
+FROM --platform=$BUILDPLATFORM golang:1.15.7-alpine AS build_deps
 
 RUN apk add --no-cache git
 
@@ -13,8 +13,8 @@ RUN go mod download
 FROM build_deps AS build
 
 COPY . .
-
-RUN CGO_ENABLED=0 go build -o webhook -ldflags '-w -extldflags "-static"' .
+ARG TARGETOS TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -o webhook -ldflags '-w -extldflags "-static"' .
 
 FROM alpine:3.9
 

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,15 @@ docker:
 		--build-arg "GIT_BRANCH=$(GIT_BRANCH)" \
 		-t "$(IMAGE_NAME):$(IMAGE_TAG)" .
 
+docker-push:
+	docker buildx build \
+		--push \
+		--build-arg "BUILD_DATE=$(BUILD_DATE)" \
+		--build-arg "GIT_COMMIT=$(GIT_COMMIT)" \
+		--build-arg "GIT_BRANCH=$(GIT_BRANCH)" \
+		--platform linux/amd64,linux/arm64,linux/arm/v7 \
+		-t "$(IMAGE_NAME):$(IMAGE_TAG)" .
+
 .PHONY: rendered-manifest.yaml
 rendered-manifest.yaml:
 	helm template \


### PR DESCRIPTION
This change will build the images for three architectures and push it to docker hub.
To use the GitHub workflow, set the DOCKERHUB_USERNAME and DOCKERHUB_TOKEN in the GitHub repository settings