### PR TITLE
feat: control RBAC stuff from values file instead of manually uncommenting stuff

### DIFF
--- a/deploy/domeneshop-webhook/templates/rbac.yaml
+++ b/deploy/domeneshop-webhook/templates/rbac.yaml
@@ -128,7 +128,7 @@ subjects:
 # This is required and must be uncommented if you are using a ClusterIssuer
 # instead of a Issuer, and you have not changed the cluster resource location
 # for cert-manager.
-{{- if .Values.rbac.allowWebhookToReadSecrets }}
+{{- if and (hasKey .Values "rbac") (.Values.rbac.allowWebhookToReadSecrets | default false) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/deploy/domeneshop-webhook/templates/rbac.yaml
+++ b/deploy/domeneshop-webhook/templates/rbac.yaml
@@ -128,38 +128,40 @@ subjects:
 # This is required and must be uncommented if you are using a ClusterIssuer
 # instead of a Issuer, and you have not changed the cluster resource location
 # for cert-manager.
-# ---
-# apiVersion: rbac.authorization.k8s.io/v1
-# kind: Role
-# metadata:
-#   name: {{ include "cert-manager-webhook-domeneshop.fullname" . }}:secret-reader
-#   namespace: {{ .Values.certManager.namespace }}
-#   labels:
-#     app: {{ include "cert-manager-webhook-domeneshop.name" . }}
-#     chart: {{ include "cert-manager-webhook-domeneshop.chart" . }}
-#     release: {{ .Release.Name }}
-#     heritage: {{ .Release.Service }}
-# rules:
-# - apiGroups: [""]
-#   resources: ["secrets"]
-#   verbs: ["get", "watch"]
-# ---
-# apiVersion: rbac.authorization.k8s.io/v1
-# kind: RoleBinding
-# metadata:
-#   name: {{ include "cert-manager-webhook-domeneshop.fullname" . }}:secret-reader
-#   namespace: {{ .Values.certManager.namespace }}
-#   labels:
-#     app: {{ include "cert-manager-webhook-domeneshop.name" . }}
-#     chart: {{ include "cert-manager-webhook-domeneshop.chart" . }}
-#     release: {{ .Release.Name }}
-#     heritage: {{ .Release.Service }}
-# roleRef:
-#   apiGroup: rbac.authorization.k8s.io
-#   kind: Role
-#   name: {{ include "cert-manager-webhook-domeneshop.fullname" . }}:secret-reader
-# subjects:
-# - apiGroup: ""
-#   kind: ServiceAccount
-#   name: {{ include "cert-manager-webhook-domeneshop.fullname" . }}
-#   namespace: {{ .Release.Namespace }}
+{{- if .Values.rbac.allowWebhookToReadSecrets }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cert-manager-webhook-domeneshop.fullname" . }}:secret-reader
+  namespace: {{ .Values.certManager.namespace }}
+  labels:
+    app: {{ include "cert-manager-webhook-domeneshop.name" . }}
+    chart: {{ include "cert-manager-webhook-domeneshop.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cert-manager-webhook-domeneshop.fullname" . }}:secret-reader
+  namespace: {{ .Values.certManager.namespace }}
+  labels:
+    app: {{ include "cert-manager-webhook-domeneshop.name" . }}
+    chart: {{ include "cert-manager-webhook-domeneshop.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cert-manager-webhook-domeneshop.fullname" . }}:secret-reader
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: {{ include "cert-manager-webhook-domeneshop.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/domeneshop-webhook/values.yaml
+++ b/deploy/domeneshop-webhook/values.yaml
@@ -41,3 +41,11 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# If you are using RBAC in you cluster, consider setting this to true
+# Grant the webhook permission to read secrets in the cert-manager namespace.
+# This is required and must be uncommented if you are using a ClusterIssuer
+# instead of a Issuer, and you have not changed the cluster resource location
+# for cert-manager.
+rbac:
+  allowWebhookToReadSecrets: false


### PR DESCRIPTION
Instead of having to manually fork/download and edit this Chart I added the option to control the extra RBAC from values.yaml instead.

Default value is set to false to not introduce any breaking changes.
It also checks if `rbac` key exists, so not to break older values file not having this new key.